### PR TITLE
BT/BLE #define BLYNK_USE_DIRECT_CONNECT

### DIFF
--- a/data_shields.js
+++ b/data_shields.js
@@ -245,6 +245,8 @@ WiFly wifly;
   Warning: Bluetooth support is in beta!
     `,
     inc: `
+#define BLYNK_USE_DIRECT_CONNECT
+
 #include <BlynkSimpleSerialBLE.h>
 #include <BLEPeripheral.h>
 #include "BLESerial.h"
@@ -280,6 +282,8 @@ BLESerial SerialBLE(BLE_REQ, BLE_RDY, BLE_RST);
   Warning: Bluetooth support is in beta!
     `,
     inc: `
+#define BLYNK_USE_DIRECT_CONNECT
+
 #include <BlynkSimpleSerialBLE.h>
     `,
     init: `


### PR DESCRIPTION
In case of Bluetooth classic or BLE connection, it is necessary to define
#define BLYNK_USE_DIRECT_CONNECT
for the optimal connection

https://github.com/blynkkk/blynk-sketch-generator/issues/78